### PR TITLE
Update includes to reflect GSM.h name change

### DIFF
--- a/examples/ATcommandsTest/ATcommandsTest.ino
+++ b/examples/ATcommandsTest/ATcommandsTest.ino
@@ -17,7 +17,7 @@
  */
 
 
-#include "GSM.h"  
+#include "GSM_GE863.h"  
 
 #ifndef DEBUG_PRINT
   #error "!!! It is necessary to enable DEBUG_PRINT macro in the Setting.h !!!"

--- a/examples/GPRS_basic/GPRS_basic.ino
+++ b/examples/GPRS_basic/GPRS_basic.ino
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "GSM.h"  
+#include "GSM_GE863.h"  
 
 
 

--- a/examples/GSMModuleOperations/GSMModuleOperations.ino
+++ b/examples/GSMModuleOperations/GSMModuleOperations.ino
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "GSM.h"  
+#include "GSM_GE863.h"  
 
 
 // ---------------------------------------------------------------------------

--- a/examples/GSMUserButtonAndLEDTest/GSMUserButtonAndLEDTest.ino
+++ b/examples/GSMUserButtonAndLEDTest/GSMUserButtonAndLEDTest.ino
@@ -14,7 +14,7 @@
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include "GSM.h"  
+#include "GSM_GE863.h"  
 
 
 // ---------------------------------------------------------------------------

--- a/examples/SMS/SMS.ino
+++ b/examples/SMS/SMS.ino
@@ -24,7 +24,7 @@
   SIM card please backup them up before inserting SIM card
   to the GSM Playground
 */
-#include "GSM.h"  
+#include "GSM_GE863.h"  
 
 // max length for SMS buffer(including also string terminator 0x00)
 // here SMS can have max. 99 characters (1 character is reserved for


### PR DESCRIPTION
GSM.h was renamed to GSM_GE863.h to avoid conflicts with the Arduino built-in GSM library so the includes in the examples needed to be updated to the new filename.